### PR TITLE
Update k8s deployment apiVersion

### DIFF
--- a/operator.yaml
+++ b/operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-enterprise-operator


### PR DESCRIPTION
Update k8s deployment apiVersion from apps/v1beta1 to apps/v1 to support kubernetes version 1.16+.  This apiVersion was deprecated and now removed.